### PR TITLE
Update Loper to support NSSecureCoding

### DIFF
--- a/Loper.xcodeproj/project.pbxproj
+++ b/Loper.xcodeproj/project.pbxproj
@@ -231,7 +231,7 @@
 				TargetAttributes = {
 					948FB09C1E4D046D002F0200 = {
 						CreatedOnToolsVersion = 8.2.1;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1030;
 						ProvisioningStyle = Automatic;
 					};
 					948FB0AB1E4D0489002F0200 = {
@@ -242,10 +242,11 @@
 			};
 			buildConfigurationList = 948FB0971E4D046D002F0200 /* Build configuration list for PBXProject "Loper" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 948FB0931E4D046D002F0200;
 			productRefGroup = 948FB09E1E4D046E002F0200 /* Products */;
@@ -335,8 +336,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 948FB0C91E4D070D002F0200 /* Loper-Debug.xcconfig */;
 			buildSettings = {
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -344,8 +344,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 948FB0C81E4D0700002F0200 /* Loper-Release.xcconfig */;
 			buildSettings = {
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Loper.xcodeproj/xcshareddata/xcschemes/Loper.xcscheme
+++ b/Loper.xcodeproj/xcshareddata/xcschemes/Loper.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Loper.xcodeproj/xcshareddata/xcschemes/Loper.xcscheme
+++ b/Loper.xcodeproj/xcshareddata/xcschemes/Loper.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "948FB09C1E4D046D002F0200"
+            BuildableName = "Loper.framework"
+            BlueprintName = "Loper"
+            ReferencedContainer = "container:Loper.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "948FB09C1E4D046D002F0200"
-            BuildableName = "Loper.framework"
-            BlueprintName = "Loper"
-            ReferencedContainer = "container:Loper.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:Loper.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Loper/EncodedObject.swift
+++ b/Loper/EncodedObject.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 internal final class EncodedObject : NSObject, NSSecureCoding {
-    let object: NSCoding
+    let object: NSSecureCoding
 
     static var supportsSecureCoding: Bool {
         return true
@@ -29,16 +29,15 @@ internal final class EncodedObject : NSObject, NSSecureCoding {
         guard let expected = NSClassFromString(klass) else {
             return nil
         }
-        guard let object = aDecoder.decodeObject(forKey: "__object") as? NSCoding else {
+
+        guard let object = aDecoder.decodeObject(of: [expected], forKey: "__object") as? NSSecureCoding else {
             return nil
         }
-        guard expected == type(of: object) else {
-            return nil;
-        }
+
         self.object = object
     }
 
-    init(object: NSCoding) {
+    init(object: NSSecureCoding) {
         self.object = object
     }
 }

--- a/Loper/Store.swift
+++ b/Loper/Store.swift
@@ -424,7 +424,7 @@ public final class Store : NSObject {
 
 public extension Store {
     @objc(setObject:forKey:inScope:)
-    public func set(object: AnyObject, forKey key: String, inScope scope: String?) {
+    func set(object: AnyObject, forKey key: String, inScope scope: String?) {
         switch object {
         case is String:
             try? self.set(string: (object as! String), forKey: key, inScope: scope)
@@ -442,37 +442,37 @@ public extension Store {
     }
 
     @objc(setBool:forKey:inScope:)
-    public func set(bool: Bool, forKey key: String, inScope scope: String?) {
+    func set(bool: Bool, forKey key: String, inScope scope: String?) {
         try? self.set(integer: (bool) ? 1 : 0, forKey: key, inScope: scope)
     }
 
     @objc(stringForKey:inScope:)
-    public func string(forKey key: String, inScope scope: String?) -> String? {
+    func string(forKey key: String, inScope scope: String?) -> String? {
         return self.read(stringForKey: key, inScope: scope)
     }
 
     @objc(dataForKey:inScope:)
-    public func data(forKey key: String, inScope scope: String?) -> Data? {
+    func data(forKey key: String, inScope scope: String?) -> Data? {
         return self.read(dataForKey: key, inScope: scope)
     }
 
     @objc(integerForKey:inScope:)
-    public func integer(forKey key: String, inScope scope: String?) -> Int64 {
+    func integer(forKey key: String, inScope scope: String?) -> Int64 {
         return self.read(integerForKey: key, inScope: scope)
     }
 
     @objc(doubleForKey:inScope:)
-    public func double(forKey key: String, inScope scope: String?) -> Double {
+    func double(forKey key: String, inScope scope: String?) -> Double {
         return self.read(doubleForKey: key, inScope: scope)
     }
 
     @objc(encodedObjectForKey:inScope:)
-    public func encodedObject(forKey key: String, inScope scope: String?) -> AnyObject? {
+    func encodedObject(forKey key: String, inScope scope: String?) -> AnyObject? {
         return self.read(encodedObjectForKey: key, inScope: scope)
     }
 
     @objc(boolForKey:inScope:)
-    public func bool(forKey key: String, inScope scope: String?) -> Bool {
+    func bool(forKey key: String, inScope scope: String?) -> Bool {
         return self.read(integerForKey: key, inScope: scope) == 1
     }
 }

--- a/Loper/Store.swift
+++ b/Loper/Store.swift
@@ -33,7 +33,7 @@ public final class Store : NSObject {
     private let tableName = "store_1"
 
     /// Has the database been opened and it's currently ready to be written to
-    public var isOpen: Bool {
+    @objc var isOpen: Bool {
         return self.queue.sync { self._open }
     }
 
@@ -140,14 +140,14 @@ public final class Store : NSObject {
         try self.set(.double(value), key, scope)
     }
 
-    /// Encodes an object conforming to NSCoding into the key store
+    /// Encodes an object conforming to NSSecureCoding into the key store
     ///
     /// - Parameters:
     ///   - value: The value to encode
     ///   - key: The key to store the value
     ///   - scope: The scope the key belongs to
     @objc(setObject:forKey:inScope:error:)
-    public func set(object value: NSCoding, forKey key: String, inScope scope: String?) throws {
+    public func set(object value: NSSecureCoding, forKey key: String, inScope scope: String?) throws {
         let enc = EncodedObject(object: value)
         let data = NSMutableData()
         let archiver = NSKeyedArchiver(forWritingWith: data)
@@ -216,7 +216,7 @@ public final class Store : NSObject {
         return object[ValueType.double.columnName] as? Double ?? 0.0
     }
 
-    /// Reads a NSCoding encoded object out of the database.
+    /// Reads a NSSecureCoding encoded object out of the database.
     ///
     /// - Parameters:
     ///   - key: The key the value is stored for
@@ -228,7 +228,7 @@ public final class Store : NSObject {
             return nil
         }
         let unarchive = NSKeyedUnarchiver(forReadingWith: data)
-        guard let encoded = unarchive.decodeObject(forKey: "__enc") as? EncodedObject else {
+        guard let encoded = unarchive.decodeObject(of: EncodedObject.self, forKey: "__enc") else {
             return nil
         }
         return encoded.object
@@ -358,7 +358,7 @@ public final class Store : NSObject {
     /// Delete's all the values in the store.
     ///
     /// Still need to run `cleanup()` to reclaim storage space in the database file.
-    public func deleteAll() throws {
+    @objc func deleteAll() throws {
         try self.queue.sync {
             guard let db = self.database else {
                 throw StoreError(.unopened)
@@ -406,18 +406,16 @@ public final class Store : NSObject {
     /// Hard resets the database
     ///
     /// If the store is already open, this will re-open after hard deleting
-    public func hardReset() throws {
-        // Mutex is recursive so we can call these locking function in the mutex
-        try self.queue.sync {
-            let reopen = self._open
-            try self.close()
-            if self.persistent {
-                let path = try self.databasePath()
-                try FileManager.default.removeItem(atPath: path)
-            }
-            if reopen {
-                try self.open()
-            }
+    @objc func hardReset() throws {
+
+        let reopen = self._open
+        try self.close()
+        if self.persistent {
+            let path = try self.databasePath()
+            try FileManager.default.removeItem(atPath: path)
+        }
+        if reopen {
+            try self.open()
         }
     }
 }
@@ -426,18 +424,18 @@ public extension Store {
     @objc(setObject:forKey:inScope:)
     func set(object: AnyObject, forKey key: String, inScope scope: String?) {
         switch object {
-        case is String:
-            try? self.set(string: (object as! String), forKey: key, inScope: scope)
-        case is Data:
-            try? self.set(data: (object as! Data), forKey: key, inScope: scope)
-        case is Int64:
-            try? self.set(integer: (object as! Int64), forKey: key, inScope: scope)
-        case is Double:
-            try? self.set(double: (object as! Double), forKey: key, inScope: scope)
-        case is NSCoding:
-            try? self.set(object: (object as! NSCoding), forKey: key, inScope: scope)
-        default:
-            assert(false, "Invalid type passed \(object).  Valid types are String, Data, Int64, Double or NSCoding")
+            case is String:
+                try? self.set(string: (object as! String), forKey: key, inScope: scope)
+            case is Data:
+                try? self.set(data: (object as! Data), forKey: key, inScope: scope)
+            case is Int64:
+                try? self.set(integer: (object as! Int64), forKey: key, inScope: scope)
+            case is Double:
+                try? self.set(double: (object as! Double), forKey: key, inScope: scope)
+            case is NSSecureCoding:
+                try? self.set(object: (object as! NSSecureCoding), forKey: key, inScope: scope)
+            default:
+                assert(false, "Invalid type passed \(object).  Valid types are String, Data, Int64, Double or NSSecureCoding")
         }
     }
 


### PR DESCRIPTION
iOS 14 is more strict about NSCoding and NSSecureCoding protocols.  This PR updates Loper to play nice with NSSecureCoding.

One thing I found was the the `hardReset` method was erroring out.  It's only called in the tests, but the error was with the DispatchQueue deadlocking on `self.close()`.  The note said "Mutex is recursive", but the tests said otherwise.

Because NSSecureCoding enforces typecasting during decode, we could remove the expected conditional in `EncodedObject.swift`

Some auto formatting too.